### PR TITLE
Remove outdated bbappend for oci-image-spec

### DIFF
--- a/recipes-containers/oci-image-spec/oci-image-spec_%.bbappend
+++ b/recipes-containers/oci-image-spec/oci-image-spec_%.bbappend
@@ -1,1 +1,0 @@
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME};branch=main"


### PR DESCRIPTION
Updated meta-virtualisation already has recipe with main branch

Signed-off-by: Yevgen Abramov <yevgen_abramov@epam.com>