### PR TITLE
[iam] Increase max items to 2 for Aos services certs

### DIFF
--- a/meta-aos-vm-main/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
+++ b/meta-aos-vm-main/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
@@ -23,7 +23,7 @@
             "ID": "online",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "Params": {
                 "Library": "/usr/lib/softhsm/libsofthsm2.so",
                 "TokenLabel": "aoscloud",
@@ -47,7 +47,7 @@
             "ID": "iam",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"
@@ -63,7 +63,7 @@
             "ID": "sm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],
@@ -78,7 +78,7 @@
             "ID": "um",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],
@@ -93,7 +93,7 @@
             "ID": "cm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth",
                 "clientAuth"

--- a/meta-aos-vm-node/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
+++ b/meta-aos-vm-node/recipes-aos/aos-iamanager/files/aos_iamanager.cfg
@@ -17,7 +17,7 @@
             "ID": "iam",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "serverAuth"
             ],
@@ -32,7 +32,7 @@
             "ID": "sm",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],
@@ -47,7 +47,7 @@
             "ID": "um",
             "Plugin": "pkcs11module",
             "Algorithm": "ecc",
-            "MaxItems": 1,
+            "MaxItems": 2,
             "ExtendedKeyUsage": [
                 "clientAuth"
             ],


### PR DESCRIPTION
We can't renew certificates that are currently in use. In order to support certificates renewing, we need to have at least two items in cert storage.